### PR TITLE
Issue #76: Add fileSize method to retrieve remote file size via SFTP

### DIFF
--- a/src/main/java/org/metricshub/ssh/SshClient.java
+++ b/src/main/java/org/metricshub/ssh/SshClient.java
@@ -350,25 +350,27 @@ public class SshClient implements AutoCloseable {
 	 * Returns the file size.
 	 *
 	 * @param filePath Path to the file on the remote system
-	 * @return the file size, null if any problem occurs
+	 * @return the file size
+	 * @throws IOException if the file does not exist
 	 */
-	public Long fileSize(final String filePath) {
+	public long fileSize(final String filePath) throws IOException {
+		SFTPv3Client sftpClient = null;
 		try {
 			// Sanity check
 			checkIfAuthenticated();
 
 			// Create the SFTP client
-			SFTPv3Client sftpClient = new SFTPv3Client(sshConnection);
+			sftpClient = new SFTPv3Client(sshConnection);
 
 			// Read the file attributes
 			final SFTPv3FileAttributes attributes = sftpClient.stat(filePath);
 
-			// Deallocate
-			sftpClient.close();
-
 			return attributes.size;
-		} catch (Exception e) {
-			return null;
+		} finally {
+			// Deallocate
+			if (sftpClient != null) {
+				sftpClient.close();
+			}
 		}
 	}
 

--- a/src/main/java/org/metricshub/ssh/SshClient.java
+++ b/src/main/java/org/metricshub/ssh/SshClient.java
@@ -346,6 +346,29 @@ public class SshClient implements AutoCloseable {
 		return pslFileResult.toString();
 	}
 
+	/**
+	 * Returns the file size.
+	 *
+	 * @param filePath Path to the file on the remote system
+	 * @return the file size
+	 * @throws IOException if the file does not exist
+	 */
+	public long fileSize(final String filePath) throws IOException {
+		// Sanity check
+		checkIfAuthenticated();
+
+		// Create the SFTP client
+		SFTPv3Client sftpClient = new SFTPv3Client(sshConnection);
+
+		// Read the file attributes
+		final SFTPv3FileAttributes attributes = sftpClient.stat(filePath);
+
+		// Deallocate
+		sftpClient.close();
+
+		return attributes.size;
+	}
+
 	private StringBuilder listSubDirectory(
 		SFTPv3Client sftpClient,
 		String remoteDirectoryPath,

--- a/src/main/java/org/metricshub/ssh/SshClient.java
+++ b/src/main/java/org/metricshub/ssh/SshClient.java
@@ -356,19 +356,18 @@ public class SshClient implements AutoCloseable {
 		try {
 			// Sanity check
 			checkIfAuthenticated();
-	
+
 			// Create the SFTP client
 			SFTPv3Client sftpClient = new SFTPv3Client(sshConnection);
-	
+
 			// Read the file attributes
 			final SFTPv3FileAttributes attributes = sftpClient.stat(filePath);
-	
+
 			// Deallocate
 			sftpClient.close();
-	
+
 			return attributes.size;
 		} catch (Exception e) {
-			
 			return null;
 		}
 	}

--- a/src/main/java/org/metricshub/ssh/SshClient.java
+++ b/src/main/java/org/metricshub/ssh/SshClient.java
@@ -1032,7 +1032,7 @@ public class SshClient implements AutoCloseable {
 	 * Check if already authenticate.
 	 */
 	void checkIfAuthenticated() {
-		if (!getSshConnection().isAuthenticationComplete()) {
+		if (getSshConnection() == null || !getSshConnection().isAuthenticationComplete()) {
 			throw new IllegalStateException("Authentication is required first");
 		}
 	}

--- a/src/main/java/org/metricshub/ssh/SshClient.java
+++ b/src/main/java/org/metricshub/ssh/SshClient.java
@@ -350,23 +350,27 @@ public class SshClient implements AutoCloseable {
 	 * Returns the file size.
 	 *
 	 * @param filePath Path to the file on the remote system
-	 * @return the file size
-	 * @throws IOException if the file does not exist
+	 * @return the file size, null if any problem occurs
 	 */
-	public long fileSize(final String filePath) throws IOException {
-		// Sanity check
-		checkIfAuthenticated();
-
-		// Create the SFTP client
-		SFTPv3Client sftpClient = new SFTPv3Client(sshConnection);
-
-		// Read the file attributes
-		final SFTPv3FileAttributes attributes = sftpClient.stat(filePath);
-
-		// Deallocate
-		sftpClient.close();
-
-		return attributes.size;
+	public Long fileSize(final String filePath) {
+		try {
+			// Sanity check
+			checkIfAuthenticated();
+	
+			// Create the SFTP client
+			SFTPv3Client sftpClient = new SFTPv3Client(sshConnection);
+	
+			// Read the file attributes
+			final SFTPv3FileAttributes attributes = sftpClient.stat(filePath);
+	
+			// Deallocate
+			sftpClient.close();
+	
+			return attributes.size;
+		} catch (Exception e) {
+			
+			return null;
+		}
 	}
 
 	private StringBuilder listSubDirectory(

--- a/src/test/java/org/metricshub/ssh/SSHClientTest.java
+++ b/src/test/java/org/metricshub/ssh/SSHClientTest.java
@@ -531,7 +531,7 @@ class SSHClientTest {
 	}
 
 	@Test
-	void testFileSize() throws Exception {
+	void testFileSize() {
 		final Connection sshConnection = Mockito.mock(Connection.class);
 		final String filePath = "/path/to/file.txt";
 
@@ -539,7 +539,7 @@ class SSHClientTest {
 		try (final SshClient sshClient = Mockito.spy(new SshClient(HOSTNAME))) {
 			Mockito.verify(sshClient, Mockito.never()).checkIfAuthenticated();
 
-			Assertions.assertThrows(IllegalStateException.class, () -> sshClient.fileSize(filePath));
+			Assertions.assertNull(sshClient.fileSize(filePath));
 		}
 
 		// Case not authenticated
@@ -547,7 +547,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(false).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertThrows(IllegalStateException.class, () -> sshClient.fileSize(filePath));
+			Assertions.assertNull(sshClient.fileSize(filePath));
 		}
 
 		// Case file does not exist (IOException)
@@ -563,7 +563,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertThrows(IOException.class, () -> sshClient.fileSize(filePath));
+			Assertions.assertNull(sshClient.fileSize(filePath));
 		}
 
 		// Case file size is 0
@@ -581,7 +581,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(0L, sshClient.fileSize(filePath));
+			Assertions.assertEquals(Long.valueOf(0L), sshClient.fileSize(filePath));
 		}
 
 		// Case file size is small (100 bytes)
@@ -599,7 +599,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(100L, sshClient.fileSize(filePath));
+			Assertions.assertEquals(Long.valueOf(100L), sshClient.fileSize(filePath));
 		}
 
 		// Case file size is large (1GB)
@@ -617,7 +617,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(1073741824L, sshClient.fileSize(filePath));
+			Assertions.assertEquals(Long.valueOf(1073741824L), sshClient.fileSize(filePath));
 		}
 	}
 }

--- a/src/test/java/org/metricshub/ssh/SSHClientTest.java
+++ b/src/test/java/org/metricshub/ssh/SSHClientTest.java
@@ -531,7 +531,7 @@ class SSHClientTest {
 	}
 
 	@Test
-	void testFileSize() {
+	void testFileSize() throws Exception {
 		final Connection sshConnection = Mockito.mock(Connection.class);
 		final String filePath = "/path/to/file.txt";
 
@@ -539,7 +539,7 @@ class SSHClientTest {
 		try (final SshClient sshClient = Mockito.spy(new SshClient(HOSTNAME))) {
 			Mockito.verify(sshClient, Mockito.never()).checkIfAuthenticated();
 
-			Assertions.assertNull(sshClient.fileSize(filePath));
+			Assertions.assertThrows(IllegalStateException.class, () -> sshClient.fileSize(filePath));
 		}
 
 		// Case not authenticated
@@ -547,7 +547,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(false).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertNull(sshClient.fileSize(filePath));
+			Assertions.assertThrows(IllegalStateException.class, () -> sshClient.fileSize(filePath));
 		}
 
 		// Case file does not exist (IOException)
@@ -563,7 +563,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertNull(sshClient.fileSize(filePath));
+			Assertions.assertThrows(IOException.class, () -> sshClient.fileSize(filePath));
 		}
 
 		// Case file size is 0
@@ -581,7 +581,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(Long.valueOf(0L), sshClient.fileSize(filePath));
+			Assertions.assertEquals(0L, sshClient.fileSize(filePath));
 		}
 
 		// Case file size is small (100 bytes)
@@ -599,7 +599,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(Long.valueOf(100L), sshClient.fileSize(filePath));
+			Assertions.assertEquals(100L, sshClient.fileSize(filePath));
 		}
 
 		// Case file size is large (1GB)
@@ -617,7 +617,7 @@ class SSHClientTest {
 			Mockito.doReturn(sshConnection).when(sshClient).getSshConnection();
 			Mockito.doReturn(true).when(sshConnection).isAuthenticationComplete();
 
-			Assertions.assertEquals(Long.valueOf(1073741824L), sshClient.fileSize(filePath));
+			Assertions.assertEquals(1073741824L, sshClient.fileSize(filePath));
 		}
 	}
 }


### PR DESCRIPTION

- Added `fileSize(String filePath)` method to retrieve remote file size via SFTP.
- Tested the method with JUnit tests and on metricshub.

